### PR TITLE
Configure Renovate - autoclosed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+}


### PR DESCRIPTION
## Action Required: Fix Renovate Configuration

There is an error with this repository's Renovate configuration that needs to be fixed. As a precaution, Renovate will stop PRs until it is resolved.

Location: `.github/renovate.json`
Error type: The renovate configuration file contains some invalid settings
Message: `packageRules:
        You have included an unsupported manager in a package rule. Your list: *.
        Supported managers are: (ansible, ansible-galaxy, argocd, asdf, azure-pipelines, batect, batect-wrapper, bazel, bazelisk, bitbucket-pipelines, buildkite, bundler, cake, cargo, cdnurl, circleci, cloudbuild, cocoapods, composer, conan, deps-edn, docker-compose, dockerfile, droneci, fleet, flux, fvm, git-submodules, github-actions, gitlabci, gitlabci-include, gomod, gradle, gradle-wrapper, helm-requirements, helm-values, helmfile, helmsman, helmv3, hermit, homebrew, html, jenkins, jsonnet-bundler, kotlin-script, kubernetes, kustomize, leiningen, maven, meteor, mint, mix, nix, nodenv, npm, nuget, nvm, osgi, pip-compile, pip_requirements, pip_setup, pipenv, poetry, pre-commit, pub, puppet, pyenv, regex, ruby-version, sbt, setup-cfg, swift, tekton, terraform, terraform-version, terragrunt, terragrunt-version, tflint-plugin, travis, velaci, woodpecker).`


Once you have resolved this problem (in this onboarding branch), Renovate will return to providing you with a preview of your repository's configuration.